### PR TITLE
Make `Float16(::BigFloat)` go through `Float64`

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -339,7 +339,7 @@ Float32(x::BigFloat, r::MPFRRoundingMode=ROUNDING_MODE[]) =
 Float32(x::BigFloat, r::RoundingMode) = Float32(x, convert(MPFRRoundingMode, r))
 
 # TODO: avoid double rounding
-Float16(x::BigFloat) = Float16(Float32(x))
+Float16(x::BigFloat) = Float16(Float64(x))
 
 promote_rule(::Type{BigFloat}, ::Type{<:Real}) = BigFloat
 promote_rule(::Type{BigInt}, ::Type{<:AbstractFloat}) = BigFloat


### PR DESCRIPTION
Doesn't fix double rounding issues, but makes them occur 2^29 times less frequently. Should have minimal performance effects.